### PR TITLE
Add ADR 0002 binding app for caliper

### DIFF
--- a/docs/decisions/0002-binding-app-for-caliper.rst
+++ b/docs/decisions/0002-binding-app-for-caliper.rst
@@ -1,0 +1,40 @@
+1. Binding app for Caliper
+==========================
+
+Status
+------
+
+Pending
+
+Context
+-------
+
+We need to decide some approach to encapsulate and structure the Caliper
+events. We have the following options for binding caliper events:
+
+-  Make our own data structure to store a caliper event (e.g. a python dict)
+
+-  Use IMS’ `caliper-python <https://github.com/IMSGlobal/caliper-python>`__ library
+
+Decision
+--------
+
+We will be using python dictionaries for processing and encapsulation of
+transformed events to keep things simple.
+
+Consequences
+------------
+
+Python dictionaries will be used for binding Caliper events. These
+events stored as python dictionaries can be converted into JSON later
+and sent to interested consumers.
+
+Rejected Alternatives
+---------------------
+
+**Use IMS’ caliper-python library**
+
+The library under discussion is not published on
+`PyPI <https://pypi.org/search/?q=caliper>`__. We’d have to fork the
+repo and add its dependency on our app. Therefore we won’t be using this
+library.


### PR DESCRIPTION
**Description:** 
Add ADR 0002 that describes why we are not using the IMS [caliper-python](https://github.com/IMSGlobal/caliper-python) app for caliper events binding and instead will be using python dictionaries.

**JIRA:** N/A

**Dependencies:** [event-tracking](https://github.com/edx/event-tracking) 

**Merge deadline:** N/A

**Installation instructions:** N/A

**Testing instructions:** N/A

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** N/A
