### PR TITLE
Fixes to "Getting Started" documentation

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -2,7 +2,7 @@ Getting Started
 ===============
 
 Setup
-----------------
+-----
 
 
 ``event-routing-backends`` is developed as a pluggable application for the edx-platform. The code in this app
@@ -11,7 +11,7 @@ edx-platform. It provides new tracking backends and processors.
 
 .. _event-tracking: https://github.com/edx/event-tracking
 
-- Add ``event_routing_backends.apps.EventRoutingBackendsConfig`` in ``INSTALLED_APPS``.
+- Add ``event_routing_backends.apps.EventRoutingBackendsConfig`` to ``INSTALLED_APPS`` in ``lms/envs/common.py``.
 - Update ``EVENT_TRACKING_BACKENDS`` setting to include backend configuration. See sample configuration for ``caliper`` backend below.
 
 Events can be filtered with `RegexFilter`_. For example in this configuration we allowing
@@ -19,43 +19,43 @@ only enrollment, seek_video and edx.video.position.changed events to be routed t
 
 .. _RegexFilter: https://github.com/edx/event-tracking/blob/master/eventtracking/processors/regex_filter.py
 
-   .. code-block:: JSON
+   .. code-block:: python
 
     EVENT_TRACKING_BACKENDS = {
-        "caliper": {
-            "ENGINE": "eventtracking.backends.async_routing.AsyncRoutingBackend",
-            "OPTIONS": {
-                "backend_name": "caliper",
-                "processors": [
+        'caliper': {
+            'ENGINE': 'eventtracking.backends.async_routing.AsyncRoutingBackend',
+            'OPTIONS': {
+                'backend_name': 'caliper',
+                'processors': [
                     {
-                        "ENGINE": "eventtracking.processors.regex_filter.RegexFilter",
-                        "OPTIONS": {
-                            "filter_type": "allowlist",
-                            "regular_expressions": [
-                                "edx.course.enrollment.*",
-                                "seek_video",
-                                "edx.video.position.changed"
+                        'ENGINE': 'eventtracking.processors.regex_filter.RegexFilter',
+                        'OPTIONS': {
+                            'filter_type': 'allowlist',
+                            'regular_expressions': [
+                                'edx.course.enrollment.*',
+                                'seek_video',
+                                'edx.video.position.changed'
                             ]
                         }
                     }
                 ],
-                "backends": {
-                    "caliper": {
-                        "ENGINE": "event_routing_backends.backends.events_router.EventsRouter",
-                        "OPTIONS": {
-                            "processors": [
+                'backends': {
+                    'caliper': {
+                        'ENGINE': 'event_routing_backends.backends.events_router.EventsRouter',
+                        'OPTIONS': {
+                            'processors': [
                                 {
-                                    "ENGINE": "event_routing_backends.processors.caliper.transformer_processor.CaliperProcessor",
-                                    "OPTIONS": {}
+                                    'ENGINE': 'event_routing_backends.processors.caliper.transformer_processor.CaliperProcessor',
+                                    'OPTIONS': {}
                                 },
                                 {
-                                    "ENGINE": "event_routing_backends.processors.caliper.envelop_processor.CaliperEnvelopProcessor",
-                                    "OPTIONS": {
-                                        "sensor_id": "http://test.com/sensors"
+                                    'ENGINE': 'event_routing_backends.processors.caliper.envelop_processor.CaliperEnvelopProcessor',
+                                    'OPTIONS': {
+                                        'sensor_id': 'http://example.com/sensors'
                                     }
                                 }
                             ],
-                            "backend_name": "caliper"
+                            'backend_name': 'caliper'
                         }
                     }
                 }
@@ -63,29 +63,29 @@ only enrollment, seek_video and edx.video.position.changed events to be routed t
         }
     }
 
-- Run migrations
+- Run migrations in lms-shell
    .. code-block:: bash
 
     $ ./manage.py lms migrate event_routing_backends
 
-- Add router configuraton from django admin under ``EVENT_ROUTING_BACKENDS`` section
+- Add router configuraton from django admin under ``EVENT_ROUTING_BACKENDS`` section (http://localhost:18000/admin/event_routing_backends/routerconfiguration/add/) using backend name ``caliper``
 
 Here is a sample configuration for a `Bearer Authentication`_ client which routes only those events where ``org_id`` is set to edX.
 `override_args` allows us to pass any additional info in event.
 
 .. _Bearer Authentication: https://swagger.io/docs/specification/authentication/bearer-authentication/
 
-   .. code-block:: JSON
+    .. code-block:: JSON
 
     [
-       {
+        {
             "override_args": {
-                "sensor": "test.sensor.com",
+                "sensor": "test.sensor.example.com",
                 "new_key": "new_value"
             },
             "host_configurations": {
                 "auth_key": "test_key",
-                "url": "http://concerned.host.com",
+                "url": "http://concerned.host.example.com",
                 "auth_scheme": "Bearer",
                 "headers": {
                     "test": "header"
@@ -96,7 +96,7 @@ Here is a sample configuration for a `Bearer Authentication`_ client which route
                 "context.org_id": "edX"
             }
         }
-     ]
+    ]
 
 
 Local development

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -70,12 +70,12 @@ only enrollment, seek_video and edx.video.position.changed events to be routed t
 
 - Add router configuraton from django admin under ``EVENT_ROUTING_BACKENDS`` section (http://localhost:18000/admin/event_routing_backends/routerconfiguration/add/) using backend name ``caliper``
 
-Here is a sample configuration for a `Bearer Authentication`_ client which routes only those events where ``org_id`` is set to edX.
-`override_args` allows us to pass any additional info in event.
+  Here is a sample configuration for a `Bearer Authentication`_ client which routes only those events where ``org_id`` is set to edX.
+  `override_args` allows us to pass any additional info in event.
 
-.. _Bearer Authentication: https://swagger.io/docs/specification/authentication/bearer-authentication/
+  .. _Bearer Authentication: https://swagger.io/docs/specification/authentication/bearer-authentication/
 
-    .. code-block:: JSON
+  .. code-block:: JSON
 
     [
         {


### PR DESCRIPTION
- Highlight config example as Python, not JSON, and use single quotes to
  match our convention
- Specify backend name to use for JSON config block
- Indicate which files and environments to make the changes and run the
  commands in
- Use example.com for any example URLs
- Indentation and other minor syntax cleanups