### PR TITLE
Modifying implementation to match caliper specification

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Unreleased
 
 *
 
+[3.0.2]
+~~~~~~~
+* Added more directions for local testing
+* changed how event data is enveloped for caliper events
+* changed url to point from http://purl.imsglobal.org/ctx/caliper/v1p1 to http://purl.imsglobal.org/ctx/caliper/v1p2
 [3.0.1]
 ~~~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Unreleased
 * Added more directions for local testing
 * changed how event data is enveloped for caliper events
 * changed url to point from http://purl.imsglobal.org/ctx/caliper/v1p1 to http://purl.imsglobal.org/ctx/caliper/v1p2
+
 [3.0.1]
 ~~~~~~~
 

--- a/docs/howto/how_to_test.rst
+++ b/docs/howto/how_to_test.rst
@@ -45,7 +45,23 @@ Follow instructions in `getting_started <docs/gettingstarted.rst>`_ doc. There i
 Change router endpoint
 ~~~~~~~~~~~~~~~~~~~~~~
 
-When adding configurations for router, change host_configuration.url key to point to a link at `webhook.site <webhook.site>`_. When you visit the site, it will automatically generate an unique link for you. Use the unique url as value for host_configuration.url key.
+When adding configurations for router, change host_configuration.url key to point to a link at `webhook.site <webhook.site>`_. When you visit the site, it will automatically generate an unique link for you. Use the unique url as value for host_configuration.url key. Example router settings to send info to webhook.site::
+
+    [
+      {
+        "host_configurations": {
+          "url": "https://webhook.site/fa5e53ee-1498-43b0-9b08-f1d1f80e4eb6",
+          "auth_scheme":"Bearer",
+          "headers":{"test":"header"}
+        },
+        "router_type": "AUTH_HEADERS",
+        "backend_name": "caliper",
+        "match_params": {}
+      }
+    ]
+
+
+
 
 Filtering events
 ~~~~~~~~~~~~~~~~

--- a/event_routing_backends/__init__.py
+++ b/event_routing_backends/__init__.py
@@ -2,6 +2,6 @@
 Various backends for receiving edX LMS events..
 """
 
-__version__ = '3.0.0'
+__version__ = '3.0.2'
 
 default_app_config = 'event_routing_backends.apps.EventRoutingBackendsConfig'  # pylint: disable=invalid-name

--- a/event_routing_backends/processors/caliper/constants.py
+++ b/event_routing_backends/processors/caliper/constants.py
@@ -2,4 +2,4 @@
 Constants related to IMS Caliper and events transformation into Caliper.
 """
 
-CALIPER_EVENT_CONTEXT = 'http://purl.imsglobal.org/ctx/caliper/v1p1'
+CALIPER_EVENT_CONTEXT = 'http://purl.imsglobal.org/ctx/caliper/v1p2'

--- a/event_routing_backends/processors/caliper/envelop_processor.py
+++ b/event_routing_backends/processors/caliper/envelop_processor.py
@@ -32,6 +32,6 @@ class CaliperEnvelopProcessor:
         return {
             'sensor': self.sensor_id,
             'sendTime': convert_datetime_to_iso(datetime.now(UTC)),
-            'data': event,
+            'data': [event],
             'dataVersion': CALIPER_EVENT_CONTEXT
         }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/complete_video(proposed).json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/complete_video(proposed).json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "action": "Ended",
     "actor": {
         "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.enrollment.activated.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.enrollment.activated.json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "action": "Activated",
     "actor": {
         "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.enrollment.deactivated.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.enrollment.deactivated.json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "action": "Deactivated",
     "actor": {
         "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.grades.problem.submitted.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.grades.problem.submitted.json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "action": "Submitted",
     "actor": {
         "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.problem.completed(proposed).json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.problem.completed(proposed).json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "action": "Completed",
     "actor": {
         "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.problem.hint.demandhint_displayed.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.problem.hint.demandhint_displayed.json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "action": "Viewed",
     "actor": {
         "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.link_clicked(anonymous_user).json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.link_clicked(anonymous_user).json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "action": "NavigatedTo",
     "actor": {
         "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.link_clicked.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.link_clicked.json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "action": "NavigatedTo",
     "actor": {
         "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.outline.selected.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.outline.selected.json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "action": "NavigatedTo",
     "actor": {
         "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.sequence.next_selected.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.sequence.next_selected.json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "action": "NavigatedTo",
     "actor": {
         "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.sequence.previous_selected.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.sequence.previous_selected.json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "action": "NavigatedTo",
     "actor": {
         "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.sequence.tab_selected.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.sequence.tab_selected.json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "action": "NavigatedTo",
     "actor": {
         "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/load_video.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/load_video.json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "action": "Retrieved",
     "actor": {
         "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/pause_video.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/pause_video.json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "action": "Paused",
     "actor": {
         "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/play_video.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/play_video.json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "action": "Started",
     "actor": {
         "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/problem_check(browser).json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/problem_check(browser).json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "action": "Submitted",
     "actor": {
         "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/problem_check(server).json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/problem_check(server).json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "action": "Submitted",
     "actor": {
         "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/seek_video.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/seek_video.json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "action": "JumpedTo",
     "actor": {
         "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/showanswer.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/showanswer.json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "action": "Viewed",
     "actor": {
         "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/stop_video.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/stop_video.json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
+    "@context": "http://purl.imsglobal.org/ctx/caliper/v1p2",
     "action": "Ended",
     "actor": {
         "id": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",

--- a/event_routing_backends/processors/caliper/tests/test_envelop_processor.py
+++ b/event_routing_backends/processors/caliper/tests/test_envelop_processor.py
@@ -34,6 +34,6 @@ class TestCaliperEnvelopProcessor(TestCase):
         self.assertEqual(result, {
             'sensor': self.sensor_id,
             'sendTime': convert_datetime_to_iso(str(FROZEN_TIME)),
-            'data': self.sample_event,
+            'data': [self.sample_event],
             'dataVersion': CALIPER_EVENT_CONTEXT
         })


### PR DESCRIPTION
Changes:
Adding more directions for local testing
Changed how data is structured:
before:
`data: {}`
after:
`data: [{}]`

Changed url to point to newest specification.