### PR TITLE
Fix use of secret for PyPI publishing

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -27,4 +27,4 @@ jobs:
          uses: pypa/gh-action-pypi-publish@master
          with:
            user: __token__
-           password: ${{ PYPI_UPLOAD_TOKEN }}
+           password: ${{ secrets.PYPI_UPLOAD_TOKEN }}


### PR DESCRIPTION
**Merge checklist:**
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
