### PR TITLE
Fix typo in class & module name, also in some comments and docstrings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Unreleased
 
 *
 
+[4.0.0]
+~~~~~~~
+
+* **Breaking change**: Rename ``CaliperEnvelopProcessor`` to ``CaliperEnvelopeProcessor`` and rename module accordingly (typo fix)
+
 [3.0.2]
 ~~~~~~~
 * Added more directions for local testing

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -49,7 +49,7 @@ only enrollment, seek_video and edx.video.position.changed events to be routed t
                                     'OPTIONS': {}
                                 },
                                 {
-                                    'ENGINE': 'event_routing_backends.processors.caliper.envelop_processor.CaliperEnvelopProcessor',
+                                    'ENGINE': 'event_routing_backends.processors.caliper.envelope_processor.CaliperEnvelopeProcessor',
                                     'OPTIONS': {
                                         'sensor_id': 'http://example.com/sensors'
                                     }

--- a/event_routing_backends/__init__.py
+++ b/event_routing_backends/__init__.py
@@ -2,6 +2,6 @@
 Various backends for receiving edX LMS events..
 """
 
-__version__ = '3.0.2'
+__version__ = '4.0.0'
 
 default_app_config = 'event_routing_backends.apps.EventRoutingBackendsConfig'  # pylint: disable=invalid-name

--- a/event_routing_backends/processors/caliper/envelope_processor.py
+++ b/event_routing_backends/processors/caliper/envelope_processor.py
@@ -9,7 +9,7 @@ from event_routing_backends.helpers import convert_datetime_to_iso
 from event_routing_backends.processors.caliper.constants import CALIPER_EVENT_CONTEXT
 
 
-class CaliperEnvelopProcessor:
+class CaliperEnvelopeProcessor:
     """
     Envelope the caliper transformed event.
     """

--- a/event_routing_backends/processors/caliper/tests/test_envelope_processor.py
+++ b/event_routing_backends/processors/caliper/tests/test_envelope_processor.py
@@ -1,5 +1,5 @@
 """
-Test the CaliperEnvelopProcessor.
+Test the CaliperEnvelopeProcessor.
 """
 from datetime import datetime
 from unittest import TestCase
@@ -9,14 +9,14 @@ from pytz import UTC
 
 from event_routing_backends.helpers import convert_datetime_to_iso
 from event_routing_backends.processors.caliper.constants import CALIPER_EVENT_CONTEXT
-from event_routing_backends.processors.caliper.envelop_processor import CaliperEnvelopProcessor
+from event_routing_backends.processors.caliper.envelope_processor import CaliperEnvelopeProcessor
 
 FROZEN_TIME = datetime(2013, 10, 3, 8, 24, 55, tzinfo=UTC)
 
 
-class TestCaliperEnvelopProcessor(TestCase):
+class TestCaliperEnvelopeProcessor(TestCase):
     """
-    Test the CaliperEnvelopProcessor.
+    Test the CaliperEnvelopeProcessor.
     """
 
     def setUp(self):
@@ -26,11 +26,11 @@ class TestCaliperEnvelopProcessor(TestCase):
         }
         self.sensor_id = 'http://test.sensor.com'
 
-    @patch('event_routing_backends.processors.caliper.envelop_processor.datetime')
-    def test_caliper_envelop_processor(self, mocked_datetime):
+    @patch('event_routing_backends.processors.caliper.envelope_processor.datetime')
+    def test_caliper_envelope_processor(self, mocked_datetime):
         mocked_datetime.now.return_value = FROZEN_TIME
 
-        result = CaliperEnvelopProcessor(sensor_id=self.sensor_id)(self.sample_event)
+        result = CaliperEnvelopeProcessor(sensor_id=self.sensor_id)(self.sample_event)
         self.assertEqual(result, {
             'sensor': self.sensor_id,
             'sendTime': convert_datetime_to_iso(str(FROZEN_TIME)),

--- a/event_routing_backends/processors/caliper/transformer.py
+++ b/event_routing_backends/processors/caliper/transformer.py
@@ -69,10 +69,10 @@ class CaliperTransformer(BaseTransformerMixin):
         """
         Transform the edX event.
 
-        Overriding this method to clean the event after successfull
+        Overriding this method to clean the event after successful
         transformation.
-        In some cases, `object[extensions]` in the transfromed event may have
-        some keys that already exist in the `object` field of transfromed event.
+        In some cases, `object[extensions]` in the transformed event may have
+        some keys that already exist in the `object` field of transformed event.
         Here we delete such fields.
 
         Returns:

--- a/event_routing_backends/processors/caliper/transformer_processor.py
+++ b/event_routing_backends/processors/caliper/transformer_processor.py
@@ -20,7 +20,7 @@ class CaliperProcessor(BaseTransformerProcessorMixin):
     This processor first transform the event using the registered transformer
     and then route the events through the configured routers.
 
-    Every router configured to be used MUST support the transfromed event type.
+    Every router configured to be used MUST support the transformed event type.
     """
 
     registry = CaliperTransformersRegistry

--- a/event_routing_backends/processors/mixins/base_transformer.py
+++ b/event_routing_backends/processors/mixins/base_transformer.py
@@ -81,7 +81,7 @@ class BaseTransformerMixin:
                 self.transformed_event[key] = value
             else:
                 raise ValueError(
-                    'Cannot find value for "{}" in transforomer {} for the event "{}"'.format(
+                    'Cannot find value for "{}" in transformer {} for the event "{}"'.format(
                         key, self.__class__.__name__, self.event['name']
                     )
                 )

--- a/event_routing_backends/processors/mixins/base_transformer_processor.py
+++ b/event_routing_backends/processors/mixins/base_transformer_processor.py
@@ -81,7 +81,7 @@ class BaseTransformerProcessorMixin:
         Transform the event using the class's registry.
 
         Making this a separate method so that subclasses can override
-        this method if those class want to do it some otherway.
+        this method if those class want to do it some other way.
 
         Arguments:
             event (dict):   Event to be transformed.

--- a/event_routing_backends/processors/xapi/transformer_processor.py
+++ b/event_routing_backends/processors/xapi/transformer_processor.py
@@ -20,7 +20,7 @@ class XApiProcessor(BaseTransformerProcessorMixin):
     This processor first transform the event using the registered transformer
     and then route the events through the configured routers.
 
-    Every router configured to be used MUST support the transfromed event type.
+    Every router configured to be used MUST support the transformed event type.
     """
 
     registry = XApiTransformersRegistry


### PR DESCRIPTION
BREAKING CHANGE: Rename CaliperEnvelopeProcessor (and module) to fix typo.

This will require updating the config on any Caliper test environment.

**Merge checklist:**
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
