### PR TITLE
Version 4.0.1 | DEBUG instead of INFO

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Unreleased
 
 *
 
+[4.0.1]
+~~~~~~~
+
+* Change a noisy INFO log message in ``TransformerRegistry.register()`` to DEBUG and fix two logging typos.
+
 [4.0.0]
 ~~~~~~~
 

--- a/event_routing_backends/__init__.py
+++ b/event_routing_backends/__init__.py
@@ -2,6 +2,6 @@
 Various backends for receiving edX LMS events..
 """
 
-__version__ = '4.0.0'
+__version__ = '4.0.1'
 
 default_app_config = 'event_routing_backends.apps.EventRoutingBackendsConfig'  # pylint: disable=invalid-name

--- a/event_routing_backends/processors/transformer_utils/registry.py
+++ b/event_routing_backends/processors/transformer_utils/registry.py
@@ -51,7 +51,7 @@ class TransformerRegistry:
             """
             if event_key in cls.mapping:
                 logger.info(
-                    'Overriding the existing transfromer {old_transformer} for event '
+                    'Overriding the existing transformer {old_transformer} for event '
                     '{event_name} with {new_transformer}'.format(
                         old_transformer=cls.mapping[event_key],
                         new_transformer=transformer,
@@ -61,8 +61,8 @@ class TransformerRegistry:
                 cls.mapping[event_key] = transformer
 
             else:
-                logger.info(
-                    'Registered transfromer {transformer} for event {event_name} '.format(
+                logger.debug(
+                    'Registered transformer {transformer} for event {event_name} '.format(
                         transformer=transformer,
                         event_name=event_key
                     )


### PR DESCRIPTION
Change a noisy INFO log message in TransformerRegistry.register() to DEBUG and fix two logging typos.


