### PR TITLE
doc: Indicate that events toggles are permanent

### DIFF
--- a/event_routing_backends/processors/caliper/__init__.py
+++ b/event_routing_backends/processors/caliper/__init__.py
@@ -9,12 +9,13 @@ from edx_toggles.toggles import SettingToggle
 # .. toggle_implementation: SettingToggle
 # .. toggle_default: False
 # .. toggle_description: Allow sending events to external servers via Caliper.
+#   Toggle intended both for gating initial release and for shutting off all
+#   Caliper events in case of emergency.
 # .. toggle_warnings: Do not enable sending of Caliper events until there has
 #   been a thorough review of PII implications and safeguards put in place to
 #   prevent accidental leakage of novel event fields to third parties. See
 #   ARCHBOM-1655 for details.
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2020-01-01
-# .. toggle_target_removal_date: 2021-07-01
+# .. toggle_use_cases: circuit_breaker
+# .. toggle_creation_date: 2021-01-01
 # .. toggle_tickets: https://openedx.atlassian.net/browse/ARCHBOM-1658
 CALIPER_EVENTS_ENABLED = SettingToggle("CALIPER_EVENTS_ENABLED", default=False)

--- a/event_routing_backends/processors/xapi/__init__.py
+++ b/event_routing_backends/processors/xapi/__init__.py
@@ -9,12 +9,13 @@ from edx_toggles.toggles import SettingToggle
 # .. toggle_implementation: SettingToggle
 # .. toggle_default: False
 # .. toggle_description: Allow sending events to external servers via xAPI.
+#   Toggle intended both for gating initial release and for shutting off all
+#   xAPI events in case of emergency.
 # .. toggle_warnings: Do not enable sending of xAPI events until there has
 #   been a thorough review of PII implications and safeguards put in place to
 #   prevent accidental leakage of novel event fields to third parties. See
 #   ARCHBOM-1655 for details.
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2020-01-01
-# .. toggle_target_removal_date: 2021-07-01
+# .. toggle_use_cases: circuit_breaker
+# .. toggle_creation_date: 2021-01-01
 # .. toggle_tickets: https://openedx.atlassian.net/browse/ARCHBOM-1658
 XAPI_EVENTS_ENABLED = SettingToggle("XAPI_EVENTS_ENABLED", default=False)


### PR DESCRIPTION
We'll want to keep these toggles because eventing is going to place
different loads on the system, and we may need to be able to shut off
external eventing in a coarse-grained way due to operational emergencies.

Also, fix creation date of toggles.