### PR TITLE
test: Delete unused tests dir

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -69,12 +69,10 @@ whitelist_externals =
 deps =
     -r{toxinidir}/requirements/quality.txt
 commands =
-    touch tests/__init__.py
-    pylint event_routing_backends tests test_utils manage.py setup.py
-    rm tests/__init__.py
-    pycodestyle event_routing_backends tests manage.py setup.py
-    pydocstyle event_routing_backends tests manage.py setup.py
-    isort --check-only --diff --recursive tests test_utils event_routing_backends manage.py setup.py test_settings.py
+    pylint event_routing_backends test_utils manage.py setup.py
+    pycodestyle event_routing_backends manage.py setup.py
+    pydocstyle event_routing_backends manage.py setup.py
+    isort --check-only --diff --recursive test_utils event_routing_backends manage.py setup.py test_settings.py
     make selfcheck
 
 [testenv:pii_check]


### PR DESCRIPTION
- Remove `tests/__init__.py`
- Remove `touch` and `rm` from tox.ini `testenv:quality` env
- Remove `tests` as an argument to quality checker commands

Running tests was causing the working tree to become dirty -- I think the
`tests/__init__.py` file was checked in by mistake at some point. But the
whole `touch`/`rm` mechanism was only needed to make sure the `tests` dir
existed because various commands tried to run quality checks on it
explicitly. This removes it as a quality target because it's otherwise
an empty directory.