### PR TITLE
refactor: limit find_nested usage

### DIFF
--- a/event_routing_backends/processors/caliper/event_transformers/problem_interaction_events.py
+++ b/event_routing_backends/processors/caliper/event_transformers/problem_interaction_events.py
@@ -72,9 +72,12 @@ class ProblemEventsTransformers(CaliperTransformer):
         Returns:
             dict
         """
-        object_id = self.find_nested('problem_id')
-        if not object_id:
-            object_id = self.find_nested('module_id')
+        object_id = None
+        event_data = None
+        data = self.event.get('data', None)
+        if data and isinstance(data, dict):
+            event_data = data.copy()
+            object_id = event_data.get('problem_id', event_data.get('module_id', None))
         if not object_id:
             object_id = get_block_id_from_event_referrer(self.event)
 
@@ -84,10 +87,9 @@ class ProblemEventsTransformers(CaliperTransformer):
             'type': OBJECT_TYPE_MAP[self.event['name']],
         })
 
-        if 'data' in self.event and isinstance(self.event['data'], dict):
-            data = self.event['data'].copy()
+        if event_data and isinstance(event_data, dict):
             extensions = self.extract_subdict_by_keys(
-                data, [
+                event_data, [
                     'module_id',
                     'grade',
                     'max_grade',

--- a/event_routing_backends/processors/caliper/event_transformers/video_events.py
+++ b/event_routing_backends/processors/caliper/event_transformers/video_events.py
@@ -74,7 +74,7 @@ class BaseVideoTransformer(CaliperTransformer):
         """
         caliper_object = self.transformed_event['object']
         data = self.event['data'].copy()
-        course_id = self.find_nested('course_id')
+        course_id = self.event['context']['course_id']
         video_id = data['id']
 
         object_id = make_video_block_id(course_id=course_id, video_id=video_id)

--- a/event_routing_backends/processors/xapi/event_transformers/enrollment_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/enrollment_events.py
@@ -26,7 +26,7 @@ class BaseEnrollmentTransformer(XApiTransformer):
         Returns:
             `Activity`
         """
-        course_id = self.find_nested('course_id')
+        course_id = self.event['context']['course_id']
         object_id = make_course_url(course_id)
 
         course = get_course_from_id(course_id)

--- a/event_routing_backends/processors/xapi/event_transformers/navigation_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/navigation_events.py
@@ -126,7 +126,7 @@ class OutlineSelectedTransformer(NavigationTransformersMixin):
             id=self.event['data']['target_url'],
             definition=ActivityDefinition(
                 type=constants.XAPI_ACTIVITY_MODULE,
-                name=LanguageMap({constants.EN: self.find_nested('target_name')}),
+                name=LanguageMap({constants.EN: self.event['data']['target_name']}),
             ),
         )
 

--- a/event_routing_backends/processors/xapi/event_transformers/problem_interaction_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/problem_interaction_events.py
@@ -82,9 +82,14 @@ class BaseProblemsTransformer(XApiTransformer, XApiVerbTransformerMixin):
         Returns:
             `Activity`
         """
+        object_id = None
+        data = self.event.get('data', None)
+        if data and isinstance(data, dict):
+            object_id = data.get('problem_id', data.get('module_id', None))
+
         # TODO: Add definition[name] of problem once it is added in the event.
         return Activity(
-            id=self.find_nested('problem_id') or self.find_nested('module_id'),
+            id=object_id,
             definition=ActivityDefinition(
                 type=constants.XAPI_ACTIVITY_INTERACTION,
             ),
@@ -226,7 +231,7 @@ class ProblemCheckTransformer(BaseProblemsTransformer):
         Returns:
             list
         """
-        answers = self.find_nested('answers')
+        answers = self.event.get('data', {}).get('answers', {})
         try:
             answers = next(iter(answers.values()))
             if isinstance(answers, str):
@@ -281,5 +286,5 @@ class ProblemCheckTransformer(BaseProblemsTransformer):
                 'raw': event_data['grade'],
                 'scaled': event_data['grade']/event_data['max_grade']
             },
-            response=self.find_nested('answers')
+            response=event_data['answers']
         )

--- a/event_routing_backends/processors/xapi/event_transformers/video_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/video_events.py
@@ -118,7 +118,7 @@ class BaseVideoTransformer(XApiTransformer, XApiVerbTransformerMixin):
         Returns:
             `Activity`
         """
-        course_id = self.find_nested('course_id')
+        course_id = self.event['context']['course_id']
         video_id = self.event['data']['id']
 
         object_id = make_video_block_id(course_id=course_id, video_id=video_id)
@@ -187,7 +187,7 @@ class VideoLoadedTransformer(BaseVideoTransformer):
 
         # TODO: Add completion threshold once its added in the platform.
         context.extensions = Extensions({
-            constants.XAPI_CONTEXT_VIDEO_LENGTH: convert_seconds_to_iso(self.find_nested('duration')),
+            constants.XAPI_CONTEXT_VIDEO_LENGTH: convert_seconds_to_iso(self.event['data']['duration']),
         })
         return context
 
@@ -213,7 +213,7 @@ class VideoInteractionTransformers(BaseVideoTransformer):
         """
         return Result(
             extensions=Extensions({
-                constants.XAPI_RESULT_VIDEO_TIME: convert_seconds_to_iso(self.find_nested('currentTime'))
+                constants.XAPI_RESULT_VIDEO_TIME: convert_seconds_to_iso(self.event['data']['currentTime'])
             })
         )
 
@@ -235,10 +235,10 @@ class VideoCompletedTransformer(BaseVideoTransformer):
         """
         return Result(
             extensions=Extensions({
-                constants.XAPI_RESULT_VIDEO_TIME: convert_seconds_to_iso(self.find_nested('duration'))
+                constants.XAPI_RESULT_VIDEO_TIME: convert_seconds_to_iso(self.event['data']['duration'])
             }),
             completion=True,
-            duration=convert_seconds_to_iso(self.find_nested('duration'))
+            duration=convert_seconds_to_iso(self.event['data']['duration'])
         )
 
 
@@ -259,7 +259,7 @@ class VideoPositionChangedTransformer(BaseVideoTransformer):
         """
         return Result(
             extensions=Extensions({
-                constants.XAPI_RESULT_VIDEO_TIME_FROM: convert_seconds_to_iso(self.find_nested('old_time')),
-                constants.XAPI_RESULT_VIDEO_TIME_TO: convert_seconds_to_iso(self.find_nested('new_time')),
+                constants.XAPI_RESULT_VIDEO_TIME_FROM: convert_seconds_to_iso(self.event['data']['old_time']),
+                constants.XAPI_RESULT_VIDEO_TIME_TO: convert_seconds_to_iso(self.event['data']['new_time']),
             }),
         )


### PR DESCRIPTION
find_nested method performs a depth first search of key in given dict.
we are using this method to search keys in the event data.
If event has some keys with same name using this method can result in
finding/passing irrelevent and/or non scalar data.
These changes limit usage of `find_nested` to only those places
where we don't have absolute path of keys to find and we have type safety checks inplace.