### PR TITLE
BOM-2558: Pin click<8.0 version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ aniso8601==9.0.1
     # via tincan
 billiard==3.6.4.0
     # via celery
-celery==5.0.5
+celery==5.1.0
     # via event-tracking
 certifi==2020.12.5
     # via requests
@@ -26,13 +26,13 @@ click-repl==0.1.6
     # via celery
 click==7.1.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
     #   click-repl
     #   code-annotations
-code-annotations==1.1.1
+code-annotations==1.1.2
     # via edx-toggles
 cryptography==3.4.7
     # via django-fernet-fields
@@ -44,7 +44,7 @@ django-crum==0.7.9
     #   edx-toggles
 django-fernet-fields==0.6
     # via -r requirements/base.in
-django-waffle==2.1.0
+django-waffle==2.2.0
     # via
     #   edx-django-utils
     #   edx-toggles
@@ -52,7 +52,6 @@ django==2.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
-    #   code-annotations
     #   django-config-models
     #   django-crum
     #   django-fernet-fields
@@ -75,19 +74,15 @@ idna==2.10
     # via requests
 isodate==0.6.0
     # via -r requirements/base.in
-jinja2==2.11.3
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   code-annotations
+jinja2==3.0.1
+    # via code-annotations
 jsonfield2==4.0.0.post0
     # via -r requirements/base.in
-kombu==5.0.2
+kombu==5.1.0
     # via celery
-markupsafe==1.1.1
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   jinja2
-newrelic==6.2.0.156
+markupsafe==2.0.1
+    # via jinja2
+newrelic==6.4.0.157
     # via edx-django-utils
 pbr==5.6.0
     # via stevedore
@@ -136,5 +131,9 @@ vine==5.0.0
     # via
     #   amqp
     #   celery
+    #   kombu
 wcwidth==0.2.5
     # via prompt-toolkit
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -42,5 +42,5 @@ tox==3.23.1
     # via -r requirements/ci.in
 urllib3==1.26.4
     # via requests
-virtualenv==20.4.6
+virtualenv==20.4.7
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,4 +10,6 @@
 
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
- 
+
+ # celery requires click<8.0
+ click<8.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -29,7 +29,7 @@ billiard==3.6.4.0
     # via
     #   -r requirements/quality.txt
     #   celery
-celery==5.0.5
+celery==5.1.0
     # via
     #   -r requirements/quality.txt
     #   event-tracking
@@ -66,7 +66,7 @@ click-repl==0.1.6
     #   celery
 click==7.1.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   celery
@@ -77,7 +77,7 @@ click==7.1.2
     #   code-annotations
     #   edx-lint
     #   pip-tools
-code-annotations==1.1.1
+code-annotations==1.1.2
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -111,7 +111,7 @@ django-crum==0.7.9
     #   edx-toggles
 django-fernet-fields==0.6
     # via -r requirements/quality.txt
-django-waffle==2.1.0
+django-waffle==2.2.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
@@ -120,7 +120,6 @@ django==2.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
-    #   code-annotations
     #   django-config-models
     #   django-crum
     #   django-fernet-fields
@@ -150,7 +149,7 @@ event-tracking==1.0.4
     # via -r requirements/quality.txt
 factory-boy==3.2.0
     # via -r requirements/quality.txt
-faker==8.2.0
+faker==8.2.1
     # via
     #   -r requirements/quality.txt
     #   factory-boy
@@ -178,16 +177,15 @@ isort==5.8.0
     #   pylint
 jinja2-pluralize==0.3.0
     # via diff-cover
-jinja2==2.11.3
+jinja2==3.0.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
     #   code-annotations
     #   diff-cover
     #   jinja2-pluralize
 jsonfield2==4.0.0.post0
     # via -r requirements/quality.txt
-kombu==5.0.2
+kombu==5.1.0
     # via
     #   -r requirements/quality.txt
     #   celery
@@ -195,9 +193,8 @@ lazy-object-proxy==1.6.0
     # via
     #   -r requirements/quality.txt
     #   astroid
-markupsafe==1.1.1
+markupsafe==2.0.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
     #   jinja2
 mccabe==0.6.1
@@ -206,7 +203,7 @@ mccabe==0.6.1
     #   pylint
 mock==4.0.3
     # via -r requirements/quality.txt
-newrelic==6.2.0.156
+newrelic==6.4.0.157
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
@@ -384,7 +381,8 @@ vine==5.0.0
     #   -r requirements/quality.txt
     #   amqp
     #   celery
-virtualenv==20.4.6
+    #   kombu
+virtualenv==20.4.7
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -399,3 +397,4 @@ wrapt==1.12.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip
+# setuptools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -26,7 +26,7 @@ billiard==3.6.4.0
     #   celery
 bleach==3.3.0
     # via readme-renderer
-celery==5.0.5
+celery==5.1.0
     # via
     #   -r requirements/test.txt
     #   event-tracking
@@ -57,14 +57,14 @@ click-repl==0.1.6
     #   celery
 click==7.1.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
     #   click-repl
     #   code-annotations
-code-annotations==1.1.1
+code-annotations==1.1.2
     # via
     #   -r requirements/test.txt
     #   edx-toggles
@@ -87,7 +87,7 @@ django-crum==0.7.9
     #   edx-toggles
 django-fernet-fields==0.6
     # via -r requirements/test.txt
-django-waffle==2.1.0
+django-waffle==2.2.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -96,7 +96,6 @@ django==2.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
-    #   code-annotations
     #   django-config-models
     #   django-crum
     #   django-fernet-fields
@@ -131,7 +130,7 @@ event-tracking==1.0.4
     # via -r requirements/test.txt
 factory-boy==3.2.0
     # via -r requirements/test.txt
-faker==8.2.0
+faker==8.2.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -147,27 +146,24 @@ iniconfig==1.1.1
     #   pytest
 isodate==0.6.0
     # via -r requirements/test.txt
-jinja2==2.11.3
+jinja2==3.0.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   code-annotations
     #   sphinx
 jsonfield2==4.0.0.post0
     # via -r requirements/test.txt
-kombu==5.0.2
+kombu==5.1.0
     # via
     #   -r requirements/test.txt
     #   celery
-markupsafe==1.1.1
+markupsafe==2.0.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   jinja2
-    #   sphinx
 mock==4.0.3
     # via -r requirements/test.txt
-newrelic==6.2.0.156
+newrelic==6.4.0.157
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -264,7 +260,7 @@ six==1.16.0
     #   readme-renderer
 snowballstemmer==2.1.0
     # via sphinx
-sphinx==4.0.1
+sphinx==4.0.2
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -272,13 +268,13 @@ sphinxcontrib-applehelp==1.0.2
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
-sphinxcontrib-htmlhelp==1.0.3
+sphinxcontrib-htmlhelp==2.0.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-qthelp==1.0.3
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.4
+sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 sqlparse==0.4.1
     # via
@@ -311,6 +307,7 @@ vine==5.0.0
     #   -r requirements/test.txt
     #   amqp
     #   celery
+    #   kombu
 wcwidth==0.2.5
     # via
     #   -r requirements/test.txt

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,7 +6,7 @@
 #
 click==7.1.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   pip-tools
 pep517==0.10.0
     # via pip-tools

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.36.2
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.1.1
+pip==21.1.2
     # via -r requirements/pip.in
-setuptools==56.2.0
+setuptools==57.0.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -24,7 +24,7 @@ billiard==3.6.4.0
     # via
     #   -r requirements/test.txt
     #   celery
-celery==5.0.5
+celery==5.1.0
     # via
     #   -r requirements/test.txt
     #   event-tracking
@@ -56,7 +56,7 @@ click-repl==0.1.6
     #   celery
 click==7.1.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   celery
     #   click-didyoumean
@@ -65,7 +65,7 @@ click==7.1.2
     #   click-repl
     #   code-annotations
     #   edx-lint
-code-annotations==1.1.1
+code-annotations==1.1.2
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -89,7 +89,7 @@ django-crum==0.7.9
     #   edx-toggles
 django-fernet-fields==0.6
     # via -r requirements/test.txt
-django-waffle==2.1.0
+django-waffle==2.2.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -98,7 +98,6 @@ django==2.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
-    #   code-annotations
     #   django-config-models
     #   django-crum
     #   django-fernet-fields
@@ -125,7 +124,7 @@ event-tracking==1.0.4
     # via -r requirements/test.txt
 factory-boy==3.2.0
     # via -r requirements/test.txt
-faker==8.2.0
+faker==8.2.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -143,29 +142,27 @@ isort==5.8.0
     # via
     #   -r requirements/quality.in
     #   pylint
-jinja2==2.11.3
+jinja2==3.0.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   code-annotations
 jsonfield2==4.0.0.post0
     # via -r requirements/test.txt
-kombu==5.0.2
+kombu==5.1.0
     # via
     #   -r requirements/test.txt
     #   celery
 lazy-object-proxy==1.6.0
     # via astroid
-markupsafe==1.1.1
+markupsafe==2.0.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
     #   jinja2
 mccabe==0.6.1
     # via pylint
 mock==4.0.3
     # via -r requirements/test.txt
-newrelic==6.2.0.156
+newrelic==6.4.0.157
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -294,9 +291,13 @@ vine==5.0.0
     #   -r requirements/test.txt
     #   amqp
     #   celery
+    #   kombu
 wcwidth==0.2.5
     # via
     #   -r requirements/test.txt
     #   prompt-toolkit
 wrapt==1.12.1
     # via astroid
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,7 +18,7 @@ billiard==3.6.4.0
     # via
     #   -r requirements/base.txt
     #   celery
-celery==5.0.5
+celery==5.1.0
     # via
     #   -r requirements/base.txt
     #   event-tracking
@@ -48,14 +48,14 @@ click-repl==0.1.6
     #   celery
 click==7.1.2
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
     #   click-repl
     #   code-annotations
-code-annotations==1.1.1
+code-annotations==1.1.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
@@ -77,7 +77,7 @@ django-crum==0.7.9
     #   edx-toggles
 django-fernet-fields==0.6
     # via -r requirements/base.txt
-django-waffle==2.1.0
+django-waffle==2.2.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -85,7 +85,6 @@ django-waffle==2.1.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
-    #   code-annotations
     #   django-config-models
     #   django-crum
     #   django-fernet-fields
@@ -109,7 +108,7 @@ event-tracking==1.0.4
     # via -r requirements/base.txt
 factory-boy==3.2.0
     # via -r requirements/test.in
-faker==8.2.0
+faker==8.2.1
     # via factory-boy
 idna==2.10
     # via
@@ -119,25 +118,23 @@ iniconfig==1.1.1
     # via pytest
 isodate==0.6.0
     # via -r requirements/base.txt
-jinja2==2.11.3
+jinja2==3.0.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   code-annotations
 jsonfield2==4.0.0.post0
     # via -r requirements/base.txt
-kombu==5.0.2
+kombu==5.1.0
     # via
     #   -r requirements/base.txt
     #   celery
-markupsafe==1.1.1
+markupsafe==2.0.1
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   jinja2
 mock==4.0.3
     # via -r requirements/test.in
-newrelic==6.2.0.156
+newrelic==6.4.0.157
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -234,7 +231,11 @@ vine==5.0.0
     #   -r requirements/base.txt
     #   amqp
     #   celery
+    #   kombu
 wcwidth==0.2.5
     # via
     #   -r requirements/base.txt
     #   prompt-toolkit
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
**Issue:** [BOM-2558](https://openedx.atlassian.net/browse/BOM-2558)

## Description
- celery requires [click<8.0](https://github.com/celery/celery/blob/master/requirements/default.txt#L5) which causes version conflicts when running [requirement upgrade build](https://github.com/edx/event-routing-backends/runs/2671928810?check_suite_focus=true). 
- The constraint may be removed once the issue https://github.com/celery/celery/issues/6753 is fixed.