### PR TITLE
ADR for an accessor method to reduce chances of PII leakage

### DIFF
--- a/docs/decisions/0005-PII-leakage-prevention.rst
+++ b/docs/decisions/0005-PII-leakage-prevention.rst
@@ -1,0 +1,27 @@
+PII leakage prevention
+================================
+
+Status
+------
+
+Pending
+
+Context
+-------
+
+``Event-routing-backends`` transforms and emits edx events that may contain PII which is not meant to be shared with learning record consumers. New xAPI and Caliper transformers are expected to be added in ``Event-routing-backends`` and therefore, a mechanism needs to be put in place to reduce chances of PII leakage via these transformers.
+
+Decision
+--------
+#. An accessor method will be developed to get values from open edx events for a specified key. Information inside the open edx event will only be accessed using this accessor method in base transformers and in event transformers.
+
+#. If a key, required by the specification (xAPI or Caliper), is not found in open edx event, this method will throw an exception.
+
+#. If a key, deemed optional by the specification (xAPI or Caliper), is not found in open edx event, this method will log this instance and return None.
+
+#. The efficacy of fuzzy comparison between keys in transformed events and potential PII keys will be evaluated in future and incorporated if found useful.
+
+Benefits
+---------
+
+#. Only the instances where this accessor is called, will need to be reviewed during code review, in order to check for potential PII leakage.


### PR DESCRIPTION
**Description:** A new accessor method named ``get_data`` will be used to access information in the edx event. This will help spot any potential PII leakage via transformers, during code review. This ADR is to inform community and developers about this approach.

**JIRA:** https://edlyio.atlassian.net/browse/ERTE-15