### PR TITLE
An ADR for versioning of xAPI and Caliper transformers

### DIFF
--- a/docs/decisions/0006-versioning-of-event-transformers.rst
+++ b/docs/decisions/0006-versioning-of-event-transformers.rst
@@ -15,8 +15,6 @@ Decision
 --------
 #. Versions of event transformers will be maintained and emitted as part of  xAPI and Caliper events.
 
-#. Versioning scheme is inspired by a semantic versioning `guide`_ (v2.0.0) authored by Tom Preston Werner.
-
 #. Transformer version will be defined by two non-negative integers X and Y representing major and minor version respectively in the form: X.Y.
 
 #. Major version (X) will be incremented when:
@@ -34,6 +32,3 @@ Decision
 #. Change logs of transformers will be maintained for both xAPI and Caliper.
 
 #. This version (X.Y) can be found in `` context [ extensions [ minorVersion ] ]`` for xAPI statement and in ``extensions [ minorVersion ]`` for Caliper event.
-
-
-.. _guide: https://semver.org/

--- a/docs/decisions/0006-versioning-of-event-transformers.rst
+++ b/docs/decisions/0006-versioning-of-event-transformers.rst
@@ -1,0 +1,39 @@
+Versioning of event transformers
+================================
+
+Status
+------
+
+Pending
+
+Context
+-------
+
+Event transformers may undergo modification in future in response to consumer request, change in specification, bug fixes etc.
+
+Decision
+--------
+#. Versions of event transformers will be maintained and emitted as part of  xAPI and Caliper events.
+
+#. Versioning scheme is inspired by a semantic versioning `guide`_ (v2.0.0) authored by Tom Preston Werner.
+
+#. Transformer version will be defined by two non-negative integers X and Y representing major and minor version respectively in the form: X.Y.
+
+#. Major version (X) will be incremented when:
+
+   #. Transformer is changed due to update in original specification (xAPI or Caliper).
+
+   #. A key is removed from or renamed in the existing transformer.
+
+   #. Value of a key is updated in the existing transformer.
+
+#. Minor version (Y) will be incremented when:
+
+   #. A key is added to an existing transformer.
+
+#. Change logs of transformers will be maintained for both xAPI and Caliper.
+
+#. This version (X.Y) can be found in `` context [ extensions [ minorVersion ] ]`` for xAPI statement and in ``extensions [ minorVersion ]`` for Caliper event.
+
+
+.. _guide: https://semver.org/


### PR DESCRIPTION
**Description:** An ADR has been added to explain the versioning scheme of xAPI and Caliper transformers.

**JIRA:** https://edlyio.atlassian.net/browse/ERTE-20