### PR TITLE
[ERTE-20-1] docs: changed status to accepted, changed version key name to eventVe…

### DIFF
--- a/docs/decisions/0006-versioning-of-event-transformers.rst
+++ b/docs/decisions/0006-versioning-of-event-transformers.rst
@@ -4,7 +4,7 @@ Versioning of event transformers
 Status
 ------
 
-Pending
+Accepted
 
 Context
 -------
@@ -31,4 +31,4 @@ Decision
 
 #. Change logs of transformers will be maintained for both xAPI and Caliper.
 
-#. This version (X.Y) can be found in `` context [ extensions [ minorVersion ] ]`` for xAPI statement and in ``extensions [ minorVersion ]`` for Caliper event.
+#. This version (X.Y) can be found in `` context [ extensions [ eventVersion ] ]`` for xAPI statement and in ``extensions [ eventVersion ]`` for Caliper event.


### PR DESCRIPTION
**Description:** changed status to accepted, changed version key name to eventVersion. This is followup PR of https://github.com/edx/event-routing-backends/pull/83/files