### PR TITLE
[ERTE-34] Refactor: Rename minorVersion to eventVersion

### DIFF
--- a/event_routing_backends/processors/caliper/event_transformers/enrollment_events.py
+++ b/event_routing_backends/processors/caliper/event_transformers/enrollment_events.py
@@ -45,7 +45,7 @@ class EnrollmentEventTransformers(CaliperTransformer):
         Returns:
             dict
         """
-        self.minor_version = 1.0
+        self.event_version = 1.0
         self.backend_name = 'caliper'
         data = self.get_data('data')
 

--- a/event_routing_backends/processors/caliper/event_transformers/navigation_events.py
+++ b/event_routing_backends/processors/caliper/event_transformers/navigation_events.py
@@ -29,7 +29,7 @@ class NavigationEventsTransformers(CaliperTransformer):
         Returns:
             dict
         """
-        self.minor_version = 1.0
+        self.event_version = 1.0
         self.backend_name = 'caliper'
         caliper_object = self.transformed_event['object']
 

--- a/event_routing_backends/processors/caliper/event_transformers/problem_interaction_events.py
+++ b/event_routing_backends/processors/caliper/event_transformers/problem_interaction_events.py
@@ -72,7 +72,7 @@ class ProblemEventsTransformers(CaliperTransformer):
         Returns:
             dict
         """
-        self.minor_version = 1.0
+        self.event_version = 1.0
         self.backend_name = 'caliper'
         object_id = None
         event_data = None

--- a/event_routing_backends/processors/caliper/event_transformers/video_events.py
+++ b/event_routing_backends/processors/caliper/event_transformers/video_events.py
@@ -72,7 +72,7 @@ class BaseVideoTransformer(CaliperTransformer):
         Returns:
             str
         """
-        self.minor_version = 1.0
+        self.event_version = 1.0
         self.backend_name = 'caliper'
         caliper_object = self.transformed_event['object']
         data = self.get_data('data')

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/complete_video(proposed).json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/complete_video(proposed).json
@@ -17,7 +17,7 @@
         "type": "VideoObject"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "MediaEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.completed.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.completed.json
@@ -15,7 +15,7 @@
         "type": "Membership"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "Event"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.enrollment.activated.enterprise.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.enrollment.activated.enterprise.json
@@ -16,7 +16,7 @@
         "type": "Membership"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "Event"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.enrollment.activated.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.enrollment.activated.json
@@ -16,7 +16,7 @@
         "type": "Membership"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "Event"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.enrollment.activated.required.only.data.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.enrollment.activated.required.only.data.json
@@ -15,7 +15,7 @@
         "type": "Membership"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "Event"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.enrollment.deactivated.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.enrollment.deactivated.json
@@ -16,7 +16,7 @@
         "type": "Membership"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "Event"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.grades.problem.submitted.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.grades.problem.submitted.json
@@ -19,7 +19,7 @@
         "type": "Assessment"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "AssessmentEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.problem.completed(proposed).json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.problem.completed(proposed).json
@@ -19,7 +19,7 @@
         "type": "AssessmentItem"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "AssessmentItemEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.problem.hint.demandhint_displayed.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.problem.hint.demandhint_displayed.json
@@ -16,7 +16,7 @@
         "type": "Frame"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "ViewEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.link_clicked(anonymous_user).json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.link_clicked(anonymous_user).json
@@ -12,7 +12,7 @@
         "type": "WebPage"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "NavigationEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.link_clicked.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.link_clicked.json
@@ -12,7 +12,7 @@
         "type": "WebPage"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "NavigationEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.link_clicked.required.only.data.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.link_clicked.required.only.data.json
@@ -12,7 +12,7 @@
         "type": "WebPage"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "NavigationEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.outline.selected.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.outline.selected.json
@@ -15,7 +15,7 @@
         "type": "WebPage"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "NavigationEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.sequence.next_selected.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.sequence.next_selected.json
@@ -17,7 +17,7 @@
         "type": "WebPage"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "NavigationEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.sequence.previous_selected.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.sequence.previous_selected.json
@@ -17,7 +17,7 @@
         "type": "WebPage"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "NavigationEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.sequence.tab_selected.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.sequence.tab_selected.json
@@ -18,7 +18,7 @@
         "type": "WebPage"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "NavigationEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/load_video.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/load_video.json
@@ -17,7 +17,7 @@
         "duration": "PT3M15S"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "Event"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/pause_video.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/pause_video.json
@@ -22,7 +22,7 @@
         "type": "MediaLocation"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "MediaEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/play_video.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/play_video.json
@@ -22,7 +22,7 @@
         "type": "MediaLocation"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "MediaEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/play_video.required.only.data.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/play_video.required.only.data.json
@@ -21,7 +21,7 @@
         "type": "MediaLocation"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "MediaEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/problem_check(browser).json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/problem_check(browser).json
@@ -15,7 +15,7 @@
         "type": "Assessment"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "AssessmentEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/problem_check(browser).required.only.data.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/problem_check(browser).required.only.data.json
@@ -13,7 +13,7 @@
         "type": "Assessment"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "AssessmentEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/problem_check(server).json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/problem_check(server).json
@@ -19,7 +19,7 @@
         "type": "Assessment"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "AssessmentEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/seek_video.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/seek_video.json
@@ -19,7 +19,7 @@
         "type": "VideoObject"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "MediaEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/showanswer.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/showanswer.json
@@ -15,7 +15,7 @@
         "type": "Frame"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "ViewEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/stop_video.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/stop_video.json
@@ -18,7 +18,7 @@
         "type": "VideoObject"
     },
     "extensions": {
-      "minorVersion": 1.0
+      "eventVersion": 1.0
     },
     "type": "MediaEvent"
 }

--- a/event_routing_backends/processors/mixins/base_transformer.py
+++ b/event_routing_backends/processors/mixins/base_transformer.py
@@ -17,7 +17,7 @@ class BaseTransformerMixin:
 
     required_fields = ()
     additional_fields = ()
-    minor_version = None
+    event_version = None
     backend_name = None
 
     def __init__(self, event):
@@ -117,7 +117,7 @@ class BaseTransformerMixin:
                 )
 
         if self.backend_name == 'caliper':
-            self.transformed_event['extensions']['minorVersion'] = self.minor_version
+            self.transformed_event['extensions']['eventVersion'] = self.event_version
 
         self.transformed_event = self.del_none(self.transformed_event)
 

--- a/event_routing_backends/processors/xapi/event_transformers/enrollment_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/enrollment_events.py
@@ -15,7 +15,7 @@ class BaseEnrollmentTransformer(XApiTransformer):
     Base transformer for enrollment events.
     """
     additional_fields = ('context', )
-    minor_version = 1.0
+    event_version = 1.0
 
     def get_object(self):
         """
@@ -50,7 +50,7 @@ class BaseEnrollmentTransformer(XApiTransformer):
                 self.extract_username()
             )
         )
-        context.extensions = Extensions({"minorVersion": self.minor_version})
+        context.extensions = Extensions({"eventVersion": self.event_version})
         return context
 
 

--- a/event_routing_backends/processors/xapi/event_transformers/navigation_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/navigation_events.py
@@ -44,7 +44,7 @@ class NavigationTransformersMixin(XApiTransformer, XApiVerbTransformerMixin):
     """
     additional_fields = ('context', )
     verb_map = VERB_MAP
-    minor_version = 1.0
+    event_version = 1.0
 
 
 @XApiTransformersRegistry.register('edx.ui.lms.link_clicked')
@@ -85,7 +85,7 @@ class LinkClickedTransformer(NavigationTransformersMixin):
             ),
             contextActivities=self.get_context_activities()
         )
-        context.extensions = Extensions({"minorVersion": self.minor_version})
+        context.extensions = Extensions({"eventVersion": self.event_version})
         return context
 
     def get_context_activities(self):
@@ -141,7 +141,7 @@ class OutlineSelectedTransformer(NavigationTransformersMixin):
                 self.extract_username()
             )
         )
-        context.extensions = Extensions({"minorVersion": self.minor_version})
+        context.extensions = Extensions({"eventVersion": self.event_version})
         return context
 
 
@@ -187,17 +187,17 @@ class TabNavigationTransformer(NavigationTransformersMixin):
         if event_name == 'edx.ui.lms.sequence.tab_selected':
             extensions = Extensions({
                 constants.XAPI_CONTEXT_STARTING_POSITION: self.get_data('data.current_tab'),
-                "minorVersion": self.minor_version
+                "eventVersion": self.event_version
             })
         elif event_name == 'edx.ui.lms.sequence.next_selected':
             extensions = Extensions({
                 constants.XAPI_CONTEXT_ENDING_POSITION: 'next unit',
-                "minorVersion": self.minor_version
+                "eventVersion": self.event_version
             })
         else:
             extensions = Extensions({
                 constants.XAPI_CONTEXT_ENDING_POSITION: 'previous unit',
-                "minorVersion": self.minor_version
+                "eventVersion": self.event_version
             })
 
         context = Context(

--- a/event_routing_backends/processors/xapi/event_transformers/problem_interaction_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/problem_interaction_events.py
@@ -75,7 +75,7 @@ class BaseProblemsTransformer(XApiTransformer, XApiVerbTransformerMixin):
     """
     additional_fields = ('context', )
     verb_map = VERB_MAP
-    minor_version = 1.0
+    event_version = 1.0
 
     def get_object(self):
         """
@@ -111,7 +111,7 @@ class BaseProblemsTransformer(XApiTransformer, XApiVerbTransformerMixin):
             ),
             contextActivities=self.get_context_activities()
         )
-        context.extensions = Extensions({"minorVersion": self.minor_version})
+        context.extensions = Extensions({"eventVersion": self.event_version})
         return context
 
     def get_context_activities(self):

--- a/event_routing_backends/processors/xapi/event_transformers/video_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/video_events.py
@@ -106,7 +106,7 @@ class BaseVideoTransformer(XApiTransformer, XApiVerbTransformerMixin):
     """
     additional_fields = ('context', )
     verb_map = VERB_MAP
-    minor_version = 1.0
+    event_version = 1.0
 
     def get_object(self):
         """
@@ -146,7 +146,7 @@ class BaseVideoTransformer(XApiTransformer, XApiVerbTransformerMixin):
             ),
             contextActivities=self.get_context_activities()
         )
-        context.extensions = Extensions({"minorVersion": self.minor_version})
+        context.extensions = Extensions({"eventVersion": self.event_version})
         return context
 
     def get_context_activities(self):
@@ -189,7 +189,7 @@ class VideoLoadedTransformer(BaseVideoTransformer):
         # TODO: Add completion threshold once its added in the platform.
         context.extensions = Extensions({
             constants.XAPI_CONTEXT_VIDEO_LENGTH: convert_seconds_to_iso(self.get_data('data.duration')),
-            "minorVersion": self.minor_version
+            "eventVersion": self.event_version
         })
         return context
 

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/complete_video(proposed).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/complete_video(proposed).json
@@ -20,7 +20,7 @@
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.completed.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.completed.json
@@ -6,7 +6,7 @@
     "context": {
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.activated.enterprise.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.activated.enterprise.json
@@ -6,7 +6,7 @@
     "context": {
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.activated.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.activated.json
@@ -6,7 +6,7 @@
     "context": {
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.activated.required.only.data.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.activated.required.only.data.json
@@ -6,7 +6,7 @@
     "context": {
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.deactivated.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.deactivated.json
@@ -6,7 +6,7 @@
     "context": {
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.grades.problem.submitted.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.grades.problem.submitted.json
@@ -14,7 +14,7 @@
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.problem.completed(proposed).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.problem.completed(proposed).json
@@ -14,7 +14,7 @@
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.problem.hint.demandhint_displayed.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.problem.hint.demandhint_displayed.json
@@ -14,7 +14,7 @@
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.link_clicked(anonymous_user).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.link_clicked(anonymous_user).json
@@ -14,7 +14,7 @@
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.link_clicked.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.link_clicked.json
@@ -14,7 +14,7 @@
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.link_clicked.required.only.data.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.link_clicked.required.only.data.json
@@ -13,7 +13,7 @@
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.outline.selected.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.outline.selected.json
@@ -6,7 +6,7 @@
     "context": {
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.sequence.next_selected.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.sequence.next_selected.json
@@ -14,7 +14,7 @@
         },
         "extensions": {
             "http://id.tincanapi.com/extension/ending-point": "next unit",
-            "minorVersion": 1.0
+            "eventVersion": 1.0
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.sequence.previous_selected.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.sequence.previous_selected.json
@@ -14,7 +14,7 @@
         },
         "extensions": {
             "http://id.tincanapi.com/extension/ending-point": "previous unit",
-            "minorVersion": 1.0
+            "eventVersion": 1.0
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.sequence.tab_selected.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.sequence.tab_selected.json
@@ -14,7 +14,7 @@
         },
         "extensions": {
             "http://id.tincanapi.com/extension/starting-position": 4,
-            "minorVersion": 1.0
+            "eventVersion": 1.0
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/load_video.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/load_video.json
@@ -33,7 +33,7 @@
         },
         "extensions": {
             "https://w3id.org/xapi/video/extensions/length": "PT3M15S",
-            "minorVersion": 1.0
+            "eventVersion": 1.0
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/pause_video.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/pause_video.json
@@ -20,7 +20,7 @@
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/play_video.empty.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/play_video.empty.json
@@ -20,7 +20,7 @@
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/play_video.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/play_video.json
@@ -20,7 +20,7 @@
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(browser).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(browser).json
@@ -14,7 +14,7 @@
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(browser).required.only.data.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(browser).required.only.data.json
@@ -13,7 +13,7 @@
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server).json
@@ -14,7 +14,7 @@
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,string_anwers).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,string_anwers).json
@@ -14,7 +14,7 @@
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,unsupported_responsetype).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,unsupported_responsetype).json
@@ -14,7 +14,7 @@
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/seek_video.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/seek_video.json
@@ -20,7 +20,7 @@
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/showanswer.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/showanswer.json
@@ -14,7 +14,7 @@
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/stop_video.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/stop_video.json
@@ -20,7 +20,7 @@
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
         "extensions": {
-          "minorVersion": 1.0
+          "eventVersion": 1.0
         }
     },
     "object": {


### PR DESCRIPTION
**Description:** Rename minorVersion to eventVersion.The argument is that people can confuse minorVersion with Y in X.Y

**JIRA:** https://edlyio.atlassian.net/browse/ERTE-34

**Dependencies:** dependencies on other outstanding PRs, issues, etc.

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
