### PR TITLE
fix: removed field eventVersion from xAPI due to restriction by specification

### DIFF
--- a/event_routing_backends/processors/caliper/event_transformers/enrollment_events.py
+++ b/event_routing_backends/processors/caliper/event_transformers/enrollment_events.py
@@ -45,7 +45,7 @@ class EnrollmentEventTransformers(CaliperTransformer):
         Returns:
             dict
         """
-        self.event_version = 1.0
+        self.event_version = "1.0"
         self.backend_name = 'caliper'
         data = self.get_data('data')
 

--- a/event_routing_backends/processors/caliper/event_transformers/navigation_events.py
+++ b/event_routing_backends/processors/caliper/event_transformers/navigation_events.py
@@ -29,7 +29,7 @@ class NavigationEventsTransformers(CaliperTransformer):
         Returns:
             dict
         """
-        self.event_version = 1.0
+        self.event_version = "1.0"
         self.backend_name = 'caliper'
         caliper_object = self.transformed_event['object']
 

--- a/event_routing_backends/processors/caliper/event_transformers/problem_interaction_events.py
+++ b/event_routing_backends/processors/caliper/event_transformers/problem_interaction_events.py
@@ -72,7 +72,7 @@ class ProblemEventsTransformers(CaliperTransformer):
         Returns:
             dict
         """
-        self.event_version = 1.0
+        self.event_version = "1.0"
         self.backend_name = 'caliper'
         object_id = None
         event_data = None

--- a/event_routing_backends/processors/caliper/event_transformers/video_events.py
+++ b/event_routing_backends/processors/caliper/event_transformers/video_events.py
@@ -72,7 +72,7 @@ class BaseVideoTransformer(CaliperTransformer):
         Returns:
             str
         """
-        self.event_version = 1.0
+        self.event_version = "1.0"
         self.backend_name = 'caliper'
         caliper_object = self.transformed_event['object']
         data = self.get_data('data')

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/complete_video(proposed).json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/complete_video(proposed).json
@@ -17,7 +17,7 @@
         "type": "VideoObject"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "MediaEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.completed.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.completed.json
@@ -15,7 +15,7 @@
         "type": "Membership"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "Event"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.enrollment.activated.enterprise.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.enrollment.activated.enterprise.json
@@ -16,7 +16,7 @@
         "type": "Membership"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "Event"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.enrollment.activated.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.enrollment.activated.json
@@ -16,7 +16,7 @@
         "type": "Membership"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "Event"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.enrollment.activated.required.only.data.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.enrollment.activated.required.only.data.json
@@ -15,7 +15,7 @@
         "type": "Membership"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "Event"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.enrollment.deactivated.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.course.enrollment.deactivated.json
@@ -16,7 +16,7 @@
         "type": "Membership"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "Event"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.grades.problem.submitted.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.grades.problem.submitted.json
@@ -19,7 +19,7 @@
         "type": "Assessment"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "AssessmentEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.problem.completed(proposed).json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.problem.completed(proposed).json
@@ -19,7 +19,7 @@
         "type": "AssessmentItem"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "AssessmentItemEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.problem.hint.demandhint_displayed.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.problem.hint.demandhint_displayed.json
@@ -16,7 +16,7 @@
         "type": "Frame"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "ViewEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.link_clicked(anonymous_user).json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.link_clicked(anonymous_user).json
@@ -12,7 +12,7 @@
         "type": "WebPage"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "NavigationEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.link_clicked.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.link_clicked.json
@@ -12,7 +12,7 @@
         "type": "WebPage"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "NavigationEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.link_clicked.required.only.data.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.link_clicked.required.only.data.json
@@ -12,7 +12,7 @@
         "type": "WebPage"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "NavigationEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.outline.selected.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.outline.selected.json
@@ -15,7 +15,7 @@
         "type": "WebPage"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "NavigationEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.sequence.next_selected.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.sequence.next_selected.json
@@ -17,7 +17,7 @@
         "type": "WebPage"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "NavigationEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.sequence.previous_selected.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.sequence.previous_selected.json
@@ -17,7 +17,7 @@
         "type": "WebPage"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "NavigationEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.sequence.tab_selected.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/edx.ui.lms.sequence.tab_selected.json
@@ -18,7 +18,7 @@
         "type": "WebPage"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "NavigationEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/load_video.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/load_video.json
@@ -17,7 +17,7 @@
         "duration": "PT3M15S"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "Event"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/pause_video.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/pause_video.json
@@ -22,7 +22,7 @@
         "type": "MediaLocation"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "MediaEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/play_video.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/play_video.json
@@ -22,7 +22,7 @@
         "type": "MediaLocation"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "MediaEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/play_video.required.only.data.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/play_video.required.only.data.json
@@ -21,7 +21,7 @@
         "type": "MediaLocation"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "MediaEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/problem_check(browser).json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/problem_check(browser).json
@@ -15,7 +15,7 @@
         "type": "Assessment"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "AssessmentEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/problem_check(browser).required.only.data.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/problem_check(browser).required.only.data.json
@@ -13,7 +13,7 @@
         "type": "Assessment"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "AssessmentEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/problem_check(server).json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/problem_check(server).json
@@ -19,7 +19,7 @@
         "type": "Assessment"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "AssessmentEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/seek_video.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/seek_video.json
@@ -19,7 +19,7 @@
         "type": "VideoObject"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "MediaEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/showanswer.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/showanswer.json
@@ -15,7 +15,7 @@
         "type": "Frame"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "ViewEvent"
 }

--- a/event_routing_backends/processors/caliper/tests/fixtures/expected/stop_video.json
+++ b/event_routing_backends/processors/caliper/tests/fixtures/expected/stop_video.json
@@ -18,7 +18,7 @@
         "type": "VideoObject"
     },
     "extensions": {
-      "eventVersion": 1.0
+      "eventVersion": "1.0"
     },
     "type": "MediaEvent"
 }

--- a/event_routing_backends/processors/xapi/event_transformers/enrollment_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/enrollment_events.py
@@ -2,7 +2,7 @@
 Transformers for enrollment related events.
 """
 
-from tincan import Activity, ActivityDefinition, Context, Extensions, LanguageMap, Verb
+from tincan import Activity, ActivityDefinition, Context, LanguageMap, Verb
 
 from event_routing_backends.helpers import get_anonymous_user_id_by_username, get_course_from_id, make_course_url
 from event_routing_backends.processors.xapi import constants
@@ -50,7 +50,6 @@ class BaseEnrollmentTransformer(XApiTransformer):
                 self.extract_username()
             )
         )
-        context.extensions = Extensions({"eventVersion": self.event_version})
         return context
 
 

--- a/event_routing_backends/processors/xapi/event_transformers/navigation_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/navigation_events.py
@@ -85,7 +85,6 @@ class LinkClickedTransformer(NavigationTransformersMixin):
             ),
             contextActivities=self.get_context_activities()
         )
-        context.extensions = Extensions({"eventVersion": self.event_version})
         return context
 
     def get_context_activities(self):
@@ -141,7 +140,6 @@ class OutlineSelectedTransformer(NavigationTransformersMixin):
                 self.extract_username()
             )
         )
-        context.extensions = Extensions({"eventVersion": self.event_version})
         return context
 
 
@@ -187,17 +185,14 @@ class TabNavigationTransformer(NavigationTransformersMixin):
         if event_name == 'edx.ui.lms.sequence.tab_selected':
             extensions = Extensions({
                 constants.XAPI_CONTEXT_STARTING_POSITION: self.get_data('data.current_tab'),
-                "eventVersion": self.event_version
             })
         elif event_name == 'edx.ui.lms.sequence.next_selected':
             extensions = Extensions({
                 constants.XAPI_CONTEXT_ENDING_POSITION: 'next unit',
-                "eventVersion": self.event_version
             })
         else:
             extensions = Extensions({
                 constants.XAPI_CONTEXT_ENDING_POSITION: 'previous unit',
-                "eventVersion": self.event_version
             })
 
         context = Context(

--- a/event_routing_backends/processors/xapi/event_transformers/problem_interaction_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/problem_interaction_events.py
@@ -7,7 +7,6 @@ from tincan import (
     ActivityList,
     Context,
     ContextActivities,
-    Extensions,
     InteractionComponent,
     InteractionComponentList,
     LanguageMap,
@@ -111,7 +110,6 @@ class BaseProblemsTransformer(XApiTransformer, XApiVerbTransformerMixin):
             ),
             contextActivities=self.get_context_activities()
         )
-        context.extensions = Extensions({"eventVersion": self.event_version})
         return context
 
     def get_context_activities(self):

--- a/event_routing_backends/processors/xapi/event_transformers/video_events.py
+++ b/event_routing_backends/processors/xapi/event_transformers/video_events.py
@@ -146,7 +146,6 @@ class BaseVideoTransformer(XApiTransformer, XApiVerbTransformerMixin):
             ),
             contextActivities=self.get_context_activities()
         )
-        context.extensions = Extensions({"eventVersion": self.event_version})
         return context
 
     def get_context_activities(self):
@@ -189,7 +188,6 @@ class VideoLoadedTransformer(BaseVideoTransformer):
         # TODO: Add completion threshold once its added in the platform.
         context.extensions = Extensions({
             constants.XAPI_CONTEXT_VIDEO_LENGTH: convert_seconds_to_iso(self.get_data('data.duration')),
-            "eventVersion": self.event_version
         })
         return context
 

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/complete_video(proposed).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/complete_video(proposed).json
@@ -19,10 +19,7 @@
                 }
             ]
         },
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.completed.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.completed.json
@@ -5,10 +5,7 @@
         "openid": "https://openedx.org/users/user-v1/32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "context": {
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.activated.enterprise.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.activated.enterprise.json
@@ -5,10 +5,7 @@
         "openid": "https://openedx.org/users/user-v1/32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "context": {
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.activated.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.activated.json
@@ -5,10 +5,7 @@
         "openid": "https://openedx.org/users/user-v1/32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "context": {
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.activated.required.only.data.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.activated.required.only.data.json
@@ -5,10 +5,7 @@
         "openid": "https://openedx.org/users/user-v1/32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "context": {
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.deactivated.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.course.enrollment.deactivated.json
@@ -5,10 +5,7 @@
         "openid": "https://openedx.org/users/user-v1/32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "context": {
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.grades.problem.submitted.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.grades.problem.submitted.json
@@ -13,10 +13,7 @@
                 }
             ]
         },
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.problem.completed(proposed).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.problem.completed(proposed).json
@@ -13,10 +13,7 @@
                 }
             ]
         },
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.problem.hint.demandhint_displayed.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.problem.hint.demandhint_displayed.json
@@ -13,10 +13,7 @@
                 }
             ]
         },
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.link_clicked(anonymous_user).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.link_clicked(anonymous_user).json
@@ -13,10 +13,7 @@
                 }
             ]
         },
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.link_clicked.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.link_clicked.json
@@ -13,10 +13,7 @@
                 }
             ]
         },
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.link_clicked.required.only.data.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.link_clicked.required.only.data.json
@@ -12,10 +12,7 @@
                 }
             ]
         },
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.outline.selected.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.outline.selected.json
@@ -5,10 +5,7 @@
         "objectType": "Agent"
     },
     "context": {
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.sequence.next_selected.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.sequence.next_selected.json
@@ -14,8 +14,7 @@
             ]
         },
         "extensions": {
-            "http://id.tincanapi.com/extension/ending-point": "next unit",
-            "eventVersion": 1.0
+            "http://id.tincanapi.com/extension/ending-point": "next unit"
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.sequence.previous_selected.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.sequence.previous_selected.json
@@ -14,8 +14,7 @@
             ]
         },
         "extensions": {
-            "http://id.tincanapi.com/extension/ending-point": "previous unit",
-            "eventVersion": 1.0
+            "http://id.tincanapi.com/extension/ending-point": "previous unit"
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.sequence.tab_selected.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/edx.ui.lms.sequence.tab_selected.json
@@ -14,8 +14,7 @@
             ]
         },
         "extensions": {
-            "http://id.tincanapi.com/extension/starting-position": 4,
-            "eventVersion": 1.0
+            "http://id.tincanapi.com/extension/starting-position": 4
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/load_video.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/load_video.json
@@ -33,8 +33,7 @@
             ]
         },
         "extensions": {
-            "https://w3id.org/xapi/video/extensions/length": "PT3M15S",
-            "eventVersion": 1.0
+            "https://w3id.org/xapi/video/extensions/length": "PT3M15S"
         },
         "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/pause_video.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/pause_video.json
@@ -19,10 +19,7 @@
                 }
             ]
         },
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/play_video.empty.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/play_video.empty.json
@@ -19,10 +19,7 @@
                 }
             ]
         },
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/play_video.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/play_video.json
@@ -19,10 +19,7 @@
                 }
             ]
         },
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(browser).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(browser).json
@@ -13,10 +13,7 @@
                 }
             ]
         },
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(browser).required.only.data.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(browser).required.only.data.json
@@ -12,10 +12,7 @@
                 }
             ]
         },
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server).json
@@ -13,10 +13,7 @@
                 }
             ]
         },
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,string_anwers).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,string_anwers).json
@@ -13,10 +13,7 @@
                 }
             ]
         },
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,unsupported_responsetype).json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/problem_check(server,unsupported_responsetype).json
@@ -13,10 +13,7 @@
                 }
             ]
         },
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/seek_video.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/seek_video.json
@@ -19,10 +19,7 @@
                 }
             ]
         },
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/showanswer.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/showanswer.json
@@ -13,10 +13,7 @@
                 }
             ]
         },
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {

--- a/event_routing_backends/processors/xapi/tests/fixtures/expected/stop_video.json
+++ b/event_routing_backends/processors/xapi/tests/fixtures/expected/stop_video.json
@@ -19,10 +19,7 @@
                 }
             ]
         },
-        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb",
-        "extensions": {
-          "eventVersion": 1.0
-        }
+        "registration": "32e08e30-f8ae-4ce2-94a8-c2bfe38a70cb"
     },
     "object": {
         "definition": {


### PR DESCRIPTION
**Description:** 
- fix: removed field eventVersion from xAPI due to restriction by specification
- fix: changed type of eventVersion in Caliper from float to string

**JIRA:** https://edlyio.atlassian.net/browse/ERTE-78