### PR TITLE
Unpin click version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ aniso8601==9.0.1
     # via tincan
 billiard==3.6.4.0
     # via celery
-celery==5.1.2
+celery==5.2.0
     # via
     #   edx-celeryutils
     #   event-tracking
@@ -20,9 +20,8 @@ cffi==1.15.0
     # via cryptography
 charset-normalizer==2.0.7
     # via requests
-click==7.1.2
+click==8.0.3
     # via
-    #   -c requirements/constraints.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -85,25 +84,25 @@ idna==3.3
     # via requests
 isodate==0.6.0
     # via -r requirements/base.in
-jinja2==3.0.2
+jinja2==3.0.3
     # via code-annotations
 jsonfield==3.1.0
     # via
     #   -r requirements/base.in
     #   edx-celeryutils
-kombu==5.2.0
+kombu==5.2.1
     # via celery
 markupsafe==2.0.1
     # via jinja2
-newrelic==7.2.2.169
+newrelic==7.2.3.170
     # via edx-django-utils
-pbr==5.6.0
+pbr==5.7.0
     # via stevedore
-prompt-toolkit==3.0.21
+prompt-toolkit==3.0.22
     # via click-repl
 psutil==5.8.0
     # via edx-django-utils
-pycparser==2.20
+pycparser==2.21
     # via cffi
 pymongo==3.12.1
     # via event-tracking

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-backports.entry-points-selectable==1.1.0
+backports.entry-points-selectable==1.1.1
     # via virtualenv
 certifi==2021.10.8
     # via requests
@@ -28,7 +28,7 @@ platformdirs==2.4.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
-py==1.10.0
+py==1.11.0
     # via tox
 pyparsing==2.4.7
     # via packaging

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,9 +11,6 @@
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
 
- # celery requires click<8.0
- click<8.0
-
 # diff-cover latest requires (pluggy>=0.13.1,<0.14.0)
 # which conflicts with pytest(pluggy>=0.12,<2.0.0) and tox(pluggy>0.12) both of these fetch pluggy==1.0.0
 # but diff-cover latest has a pin (pluggy<1.0.0a1)

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,7 +21,7 @@ attrs==21.2.0
     # via
     #   -r requirements/quality.txt
     #   pytest
-backports.entry-points-selectable==1.1.0
+backports.entry-points-selectable==1.1.1
     # via
     #   -r requirements/ci.txt
     #   virtualenv
@@ -29,7 +29,7 @@ billiard==3.6.4.0
     # via
     #   -r requirements/quality.txt
     #   celery
-celery==5.1.2
+celery==5.2.0
     # via
     #   -r requirements/quality.txt
     #   edx-celeryutils
@@ -48,9 +48,8 @@ charset-normalizer==2.0.7
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-click==7.1.2
+click==8.0.3
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   celery
@@ -185,11 +184,11 @@ iniconfig==1.1.1
     #   pytest
 isodate==0.6.0
     # via -r requirements/quality.txt
-isort==5.9.3
+isort==5.10.1
     # via
     #   -r requirements/quality.txt
     #   pylint
-jinja2==3.0.2
+jinja2==3.0.3
     # via
     #   -r requirements/quality.txt
     #   code-annotations
@@ -201,7 +200,7 @@ jsonfield==3.1.0
     # via
     #   -r requirements/quality.txt
     #   edx-celeryutils
-kombu==5.2.0
+kombu==5.2.1
     # via
     #   -r requirements/quality.txt
     #   celery
@@ -219,7 +218,7 @@ mccabe==0.6.1
     #   pylint
 mock==4.0.3
     # via -r requirements/quality.txt
-newrelic==7.2.2.169
+newrelic==7.2.3.170
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
@@ -231,7 +230,7 @@ packaging==21.2
     #   tox
 path==16.2.0
     # via edx-i18n-tools
-pbr==5.6.0
+pbr==5.7.0
     # via
     #   -r requirements/quality.txt
     #   stevedore
@@ -256,7 +255,7 @@ pluggy==1.0.0
     #   tox
 polib==1.1.1
     # via edx-i18n-tools
-prompt-toolkit==3.0.21
+prompt-toolkit==3.0.22
     # via
     #   -r requirements/quality.txt
     #   click-repl
@@ -264,7 +263,7 @@ psutil==5.8.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
-py==1.10.0
+py==1.11.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -272,7 +271,7 @@ py==1.10.0
     #   tox
 pycodestyle==2.8.0
     # via -r requirements/quality.txt
-pycparser==2.20
+pycparser==2.21
     # via
     #   -r requirements/quality.txt
     #   cffi

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -26,7 +26,7 @@ billiard==3.6.4.0
     #   celery
 bleach==4.1.0
     # via readme-renderer
-celery==5.1.2
+celery==5.2.0
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
@@ -43,9 +43,8 @@ charset-normalizer==2.0.7
     # via
     #   -r requirements/test.txt
     #   requests
-click==7.1.2
+click==8.0.3
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   celery
     #   click-didyoumean
@@ -150,7 +149,7 @@ idna==3.3
     # via
     #   -r requirements/test.txt
     #   requests
-imagesize==1.2.0
+imagesize==1.3.0
     # via sphinx
 iniconfig==1.1.1
     # via
@@ -158,7 +157,7 @@ iniconfig==1.1.1
     #   pytest
 isodate==0.6.0
     # via -r requirements/test.txt
-jinja2==3.0.2
+jinja2==3.0.3
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -167,7 +166,7 @@ jsonfield==3.1.0
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
-kombu==5.2.0
+kombu==5.2.1
     # via
     #   -r requirements/test.txt
     #   celery
@@ -177,7 +176,7 @@ markupsafe==2.0.1
     #   jinja2
 mock==4.0.3
     # via -r requirements/test.txt
-newrelic==7.2.2.169
+newrelic==7.2.3.170
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -187,7 +186,7 @@ packaging==21.2
     #   bleach
     #   pytest
     #   sphinx
-pbr==5.6.0
+pbr==5.7.0
     # via
     #   -r requirements/test.txt
     #   stevedore
@@ -195,7 +194,7 @@ pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-prompt-toolkit==3.0.21
+prompt-toolkit==3.0.22
     # via
     #   -r requirements/test.txt
     #   click-repl
@@ -203,11 +202,11 @@ psutil==5.8.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-py==1.10.0
+py==1.11.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pycparser==2.20
+pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,10 +4,8 @@
 #
 #    make upgrade
 #
-click==7.1.2
-    # via
-    #   -c requirements/constraints.txt
-    #   pip-tools
+click==8.0.3
+    # via pip-tools
 pep517==0.12.0
     # via pip-tools
 pip-tools==6.4.0

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.37.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==21.3.1
     # via -r requirements/pip.in
-setuptools==58.4.0
+setuptools==58.5.3
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -24,7 +24,7 @@ billiard==3.6.4.0
     # via
     #   -r requirements/test.txt
     #   celery
-celery==5.1.2
+celery==5.2.0
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
@@ -41,9 +41,8 @@ charset-normalizer==2.0.7
     # via
     #   -r requirements/test.txt
     #   requests
-click==7.1.2
+click==8.0.3
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   celery
     #   click-didyoumean
@@ -151,11 +150,11 @@ iniconfig==1.1.1
     #   pytest
 isodate==0.6.0
     # via -r requirements/test.txt
-isort==5.9.3
+isort==5.10.1
     # via
     #   -r requirements/quality.in
     #   pylint
-jinja2==3.0.2
+jinja2==3.0.3
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -163,7 +162,7 @@ jsonfield==3.1.0
     # via
     #   -r requirements/test.txt
     #   edx-celeryutils
-kombu==5.2.0
+kombu==5.2.1
     # via
     #   -r requirements/test.txt
     #   celery
@@ -177,7 +176,7 @@ mccabe==0.6.1
     # via pylint
 mock==4.0.3
     # via -r requirements/test.txt
-newrelic==7.2.2.169
+newrelic==7.2.3.170
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -185,7 +184,7 @@ packaging==21.2
     # via
     #   -r requirements/test.txt
     #   pytest
-pbr==5.6.0
+pbr==5.7.0
     # via
     #   -r requirements/test.txt
     #   stevedore
@@ -195,7 +194,7 @@ pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-prompt-toolkit==3.0.21
+prompt-toolkit==3.0.22
     # via
     #   -r requirements/test.txt
     #   click-repl
@@ -203,13 +202,13 @@ psutil==5.8.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-py==1.10.0
+py==1.11.0
     # via
     #   -r requirements/test.txt
     #   pytest
 pycodestyle==2.8.0
     # via -r requirements/quality.in
-pycparser==2.20
+pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,7 +18,7 @@ billiard==3.6.4.0
     # via
     #   -r requirements/base.txt
     #   celery
-celery==5.1.2
+celery==5.2.0
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
@@ -35,9 +35,8 @@ charset-normalizer==2.0.7
     # via
     #   -r requirements/base.txt
     #   requests
-click==7.1.2
+click==8.0.3
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   celery
     #   click-didyoumean
@@ -132,7 +131,7 @@ iniconfig==1.1.1
     # via pytest
 isodate==0.6.0
     # via -r requirements/base.txt
-jinja2==3.0.2
+jinja2==3.0.3
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -140,7 +139,7 @@ jsonfield==3.1.0
     # via
     #   -r requirements/base.txt
     #   edx-celeryutils
-kombu==5.2.0
+kombu==5.2.1
     # via
     #   -r requirements/base.txt
     #   celery
@@ -150,19 +149,19 @@ markupsafe==2.0.1
     #   jinja2
 mock==4.0.3
     # via -r requirements/test.in
-newrelic==7.2.2.169
+newrelic==7.2.3.170
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
 packaging==21.2
     # via pytest
-pbr==5.6.0
+pbr==5.7.0
     # via
     #   -r requirements/base.txt
     #   stevedore
 pluggy==1.0.0
     # via pytest
-prompt-toolkit==3.0.21
+prompt-toolkit==3.0.22
     # via
     #   -r requirements/base.txt
     #   click-repl
@@ -170,9 +169,9 @@ psutil==5.8.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-py==1.10.0
+py==1.11.0
     # via pytest
-pycparser==2.20
+pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi


### PR DESCRIPTION
Description:
We’d pinned the click version because of celery. Now the new version of celery has bumped the required click constraint so we can remove the click constraint from the constraints.txt file.